### PR TITLE
Troubleshooting script for Windows / MacOS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Viio"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -62,19 +62,25 @@ To check Agent installation we prepare `*.troubleshooting` script for each suppo
 
 ### MacOS script
 
-Run script `macos.troubleshooting.sh` with `sudo` and check console output.
-
-To share it with Viio dev team please save standard and error outputs into file using `&>` for redirection:
+Run script `macos.troubleshooting.sh` and check console output:
 
 ```sh
-curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh -o macos.troubleshooting.sh
+bash -c "$(curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh)"
+```
 
-sudo bash macos.troubleshooting.sh &> result.txt
+To share output with Viio dev team please save standard and error outputs into file using `&>` for redirection:
+
+```sh
+bash -c "$(curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh)" &> result.txt
 ```
 
 ### Windows script
 
-Run script `windows.troubleshooting.ps1` in PowerShell opened with Administrator privileges and check console output.
+Run script `windows.troubleshooting.ps1` in PowerShell opened with Administrator privileges and check console output:
+
+```powershell
+([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.troubleshooting.ps1'))).Invoke()
+```
 
 To share it with Viio dev team please save standard and error outputs into file using `*>` for redirection:
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Run script `macos.troubleshooting.sh` with `sudo` and check console output.
 
 To share it with Viio dev team please save standard and error outputs into file using `&>` for redirection:
 
-```bash
-sudo ./macos.troubleshooting.sh &> result.txt
+```sh
+curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh -o macos.troubleshooting.sh
+
+sudo bash macos.troubleshooting.sh &> result.txt
 ```
 
 ### Windows script

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo rm /etc/viio.conf
 
 ## Windows
 
-### Using Powershell
+### Using PowerShell
 
 Installation with specified Viio customer key:
 
@@ -58,7 +58,7 @@ ENDLOCAL
 
 ## Troubleshooting
 
-To check Agent installation we prepare `*.troubleshooting` script for each supported OS.
+To check Agent installation we've prepared troubleshooting script for each supported OS.
 
 ### MacOS script
 
@@ -68,7 +68,7 @@ Run script `macos.troubleshooting.sh` and check console output:
 bash -c "$(curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh)"
 ```
 
-To share output with Viio dev team please save standard and error outputs into file using `&>` for redirection:
+To share the output with the Viio dev team, please save standard and error outputs into a file using `&>` for redirection:
 
 ```sh
 bash -c "$(curl -L https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/macos.troubleshooting.sh)" &> result.txt
@@ -82,7 +82,7 @@ Run script `windows.troubleshooting.ps1` in PowerShell opened with Administrator
 ([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.troubleshooting.ps1'))).Invoke()
 ```
 
-To share it with Viio dev team please save standard and error outputs into file using `*>` for redirection:
+To share the output with the Viio dev team, please save standard and error outputs into a file using `*>` for redirection:
 
 ```powershell
 ([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.troubleshooting.ps1'))).Invoke() *> "result.txt"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,17 @@ ENDLOCAL
 ```
 
 > *NOTE:* `SET email=%1` means that email will be passed to script by MDM solution as the 1st argument, e.g., `script.cmd test@example.com`. If the email is passed as the 2nd argument, the line will look `SET email=%2` and so on for 3rd, 4th, etc. order of argument.
+
+## Troubleshooting
+
+To check Agent installation we prepare `*.troubleshooting` script for each supported OS.
+
+### MacOS script
+
+Run script `macos.troubleshooting.sh` with `sudo` and check console output.
+
+To share it with Viio dev team please save standard output and error into file using `&>` for redirection:
+
+```bash
+sudo ./macos.troubleshooting.sh &> result.txt
+```

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ sudo rm /etc/viio.conf
 
 Installation with specified Viio customer key:
 
-```powerhsell
+```powershell
 ([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.install.ps1'))).Invoke("SPECIFY_CUSTOMER_KEY_HERE")
 ```
 
 Installation with specified Viio customer key and Employee email of computer:
 
-```powerhsell
+```powershell
 ([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.install.ps1'))).Invoke("SPECIFY_CUSTOMER_KEY_HERE", "SPECIFY_EMPLOYEE_EMAIL_HERE")
 ```
 
@@ -79,5 +79,5 @@ Run script `windows.troubleshooting.ps1` in PowerShell opened with Administrator
 To share it with Viio dev team please save standard and error outputs into file using `*>` for redirection:
 
 ```powershell
-./windows.troubleshooting.ps1 *> result.txt
+([scriptblock]::Create((Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/viio-io/agent-installer-scripts/main/windows.troubleshooting.ps1'))).Invoke() *> "result.txt"
 ```

--- a/README.md
+++ b/README.md
@@ -64,8 +64,18 @@ To check Agent installation we prepare `*.troubleshooting` script for each suppo
 
 Run script `macos.troubleshooting.sh` with `sudo` and check console output.
 
-To share it with Viio dev team please save standard output and error into file using `&>` for redirection:
+To share it with Viio dev team please save standard and error outputs into file using `&>` for redirection:
 
 ```bash
 sudo ./macos.troubleshooting.sh &> result.txt
+```
+
+### Windows script
+
+Run script `windows.troubleshooting.ps1` in PowerShell opened with Administrator privileges and check console output.
+
+To share it with Viio dev team please save standard and error outputs into file using `*>` for redirection:
+
+```powershell
+./windows.troubleshooting.ps1 *> result.txt
 ```

--- a/macos.troubleshooting.sh
+++ b/macos.troubleshooting.sh
@@ -44,9 +44,13 @@ check_daemon_status() {
 check_url_accessibility() {
     echo ""
     local url=$1
-    local response=$(curl --silent --fail "$url")
+    local response
 
-    if [ $? -eq 0 ]; then
+    # Execute curl and capture response; also store the exit status
+    response=$(curl --silent --fail "$url")
+    local status=$?
+
+    if [ $status -eq 0 ]; then  # Curl command was successful
         echo "URL $url is accessible."
         if [ -z "$response" ]; then
             echo "Response content is empty."
@@ -97,19 +101,20 @@ get_service_logs() {
 
     # Using the log command to filter logs based on the service name
     # Adjust the predicate according to your service's logging subsystem or other criteria
-    $SUDO log show --predicate "(subsystem == '$service_name' OR process == '$service_name')" --info --last $time_span --debug
+    $SUDO log show --predicate "(subsystem == '$service_name' OR process == '$service_name')" --info --last "$time_span" --debug
 }
 
 # Function to generate DeviceID combining System Drive Serial Number and Platform Serial Number
 print_device_id() {
     echo ""
 
-    local system_drive_serial=$(system_profiler SPSerialATADataType | sed -En 's/.*Serial Number: ([\\d\\w]*)//p')
+    local system_drive_serial
+    local platform_serial
+
+    system_drive_serial=$(system_profiler SPSerialATADataType | sed -En 's/.*Serial Number: ([\\d\\w]*)//p')
+    platform_serial=$(ioreg -l | grep IOPlatformSerialNumber | sed 's/.*= //' | sed 's/\"//g')
 
     echo "System drive serial number: $system_drive_serial"
-
-    local platform_serial=$(ioreg -l | grep IOPlatformSerialNumber | sed 's/.*= //' | sed 's/\"//g')
-
     echo "Platform serial number: $platform_serial"
 }
 

--- a/macos.troubleshooting.sh
+++ b/macos.troubleshooting.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Service name (you should replace this with your specific service name)
+SERVICE_NAME="io.viio.agent.metalauncher"
+
+# Check if the script is running with sudo
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run as root. Please use sudo."
+    exit 1
+fi
+
+# Function to check if the service is installed and print the directory
+check_service_installed() {
+    echo "Checking if $SERVICE_NAME is installed..."
+
+    if [ -f /Library/LaunchDaemons/$SERVICE_NAME.plist ]; then
+        echo "$SERVICE_NAME is installed in /Library/LaunchDaemons/"
+    elif [ -f ~/Library/LaunchAgents/$SERVICE_NAME.plist ]; then
+        echo "$SERVICE_NAME is installed in ~/Library/LaunchAgents/"
+    else
+        echo "$SERVICE_NAME is not installed."
+    fi
+}
+
+# Function to check if the service is loaded (running) and display its status
+check_daemon_status() {
+    echo ""
+    echo "Checking if $SERVICE_NAME is running..."
+    if launchctl list | grep -q $SERVICE_NAME; then
+        echo "$SERVICE_NAME is running."
+    else
+        echo "$SERVICE_NAME is not running."
+    fi
+
+    echo ""
+    echo "Service status:"
+    launchctl list | grep $SERVICE_NAME
+}
+
+# Function to check if a URL is accessible
+check_url_accessibility() {
+    echo ""
+    local url=$1
+    if curl --output /dev/null --silent --get --fail "$url"; then
+        echo "URL $url is accessible."
+    else
+        echo "URL $url is not accessible."
+    fi
+}
+
+# Function to list all files in an installation directory
+list_files_in_directory() {
+    local install_folder=$1
+
+    echo ""
+    if [ -d "$install_folder" ]; then
+        echo "Listing files in $install_folder:"
+        ls -l "$install_folder"
+    else
+        echo "Directory $install_folder does not exist."
+    fi
+}
+
+# Function to check if an environment variable is provided
+check_env_variable() {
+    local var_name=$1
+
+    # Using indirect variable reference to get the value of the variable with name in var_name
+    local var_value=${!var_name}
+
+    echo ""
+    if [ -z "$var_value" ]; then
+        echo "Environment variable '$var_name' is not set or is empty."
+        return 1
+    else
+        echo "Environment variable '$var_name' is set to '$var_value'."
+        return 0
+    fi
+}
+
+# Function to check if a file exists and print its content
+print_file_content() {
+    local file_path=$1
+
+    echo ""
+    if [ -f "$file_path" ]; then
+        echo "File exists: $file_path"
+        echo "Content of $file_path:"
+        cat "$file_path"
+    else
+        echo "File does not exist: $file_path"
+        return 1
+    fi
+}
+
+# Function to retrieve logs for a service using the Unified Logging System
+get_service_logs() {
+    local service_name=$1
+    local time_span=${2:-1h}  # Default time span is last 1 hour, can be overridden
+
+    echo ""
+    echo "Retrieving logs for $service_name for the past $time_span..."
+
+    # Using the log command to filter logs based on the service name
+    # Adjust the predicate according to your service's logging subsystem or other criteria
+    log show --predicate "(subsystem == '$service_name' OR process == '$service_name')" --info --last $time_span --debug
+}
+
+### MAIN
+
+# Check if the service is installed
+check_service_installed
+
+# Check daemon status
+check_daemon_status
+
+# Check APIs accessibility
+check_url_accessibility "https://api.viio.io/employee-management/v1/employees/email/test@mail.com"
+check_url_accessibility "https://api.viio.io/desktop/v1/settings/test"
+
+# List all files in the installation directory
+list_files_in_directory "/usr/local/viio"
+
+# Check globally set env variables
+check_env_variable "VIIO_CUSTOMER_KEY"
+check_env_variable "VIIO_EMPLOYEE_EMAIL"
+check_env_variable "VIIO_INSTALLER_USER"
+
+# Print some config files
+print_file_content "/etc/viio.conf"
+print_file_content "/var/log/viio_stderr.log"
+print_file_content "/usr/local/viio/appsettings.json"
+print_file_content "/usr/local/viio/appsettings-after-install.json"
+print_file_content "/usr/local/viio/info.json"
+
+# Getting logs from operating system
+get_service_logs $SERVICE_NAME

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -29,8 +29,8 @@ function Confirm-ServiceInstalled {
     }
 }
 
-# Function to print all files in service installation folder
-function Get-ServiceInstallFolderAndFiles {
+# Function to get the folder path of a service's executable
+function Get-ServiceExecutablePath {
     param (
         [string]$serviceName
     )
@@ -38,7 +38,6 @@ function Get-ServiceInstallFolderAndFiles {
     # Get the service object
     $service = Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'"
 
-    Write-Host ""
     if ($service) {
         # Extract the executable path from the service's executable path
         # Remove double quotes and extract the directory path
@@ -46,31 +45,81 @@ function Get-ServiceInstallFolderAndFiles {
         $serviceFolderPath = [System.IO.Path]::GetDirectoryName($executablePath)
 
         Write-Host "Executable Path for Service '$serviceName': $executablePath"
-        Write-Host ""
-        Write-Host "Files in the folder of the executable:"
 
-        # Get and list all files in the directory with details
-        Get-ChildItem -Path $serviceFolderPath -File | Select-Object Name, Length, CreationTime, LastWriteTime | Format-List
+        # Return the folder path
+        return $serviceFolderPath
     } else {
         Write-Host "Service '$serviceName' is not installed on this system."
+        return $null
     }
 }
 
+# Function to retrieve and display information about all files in a specified directory
+function Get-DirectoryFilesInfo {
+    param (
+        [string]$directoryPath
+    )
+
+    Write-Host ""
+    if (Test-Path -Path $directoryPath) {
+        Write-Host "Files in the directory ($directoryPath):"
+        Get-ChildItem -Path "$directoryPath" -File | Select-Object Name, Length, CreationTime, LastWriteTime | Format-List
+    } else {
+        Write-Host "Directory not found: $directoryPath" -ForegroundColor Red
+    }
+}
+
+# Function to read and print the content of a specified file
+function Get-FileContent {
+    param (
+        [string]$filePath
+    )
+
+    Write-Host ""
+    if (Test-Path $filePath) {
+        Write-Host "Content of the file ($filePath):" -ForegroundColor Green
+        Get-Content -Path $filePath
+    } else {
+        Write-Host "File not found: $filePath" -ForegroundColor Red
+    }
+}
+
+# Function to test URL availability
 function Test-ServiceApiAvailability {
     param (
         [string]$url
     )
 
+    Write-Host ""
     try {
         $response = Invoke-WebRequest -Uri $url -Method 'GET' -UseBasicParsing
         if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
             Write-Host "API at $url is available. Status Code: $($response.StatusCode)" -ForegroundColor Green
+
+            # Check if response content is not empty
+            if ([string]::IsNullOrWhiteSpace($response.Content)) {
+                Write-Host "Response content is empty." -ForegroundColor Cyan
+            } else {
+                Write-Host "Response Content: $($response.Content)" -ForegroundColor Cyan
+            }
         } else {
             Write-Host "API at $url responded, but with a non-successful status code: $($response.StatusCode)" -ForegroundColor Yellow
         }
     } catch {
         Write-Host "API at $url is not available. Error: $_" -ForegroundColor Red
     }
+}
+
+# Function to get device id
+function Get-DeviceUUID {
+    $computerSystemProduct = Get-WmiObject -Class Win32_ComputerSystemProduct
+    $uuid = $computerSystemProduct.UUID
+
+    Write-Host ""
+    Write-Host "Device UUID: $uuid"
+
+    # Get Machine Name
+    Write-Host "Machine Name: $env:COMPUTERNAME"
 }
 
 # MAINs
@@ -84,11 +133,22 @@ if (-not (Test-AdminPrivileges)) {
 Confirm-ServiceInstalled -serviceName $SERVICE_NAME
 
 # Print all files in service installation folder
-Get-ServiceInstallFolderAndFiles -serviceName $SERVICE_NAME
+$folderOfServiceExecutable = Get-ServiceExecutablePath -serviceName $SERVICE_NAME
+Get-DirectoryFilesInfo -directoryPath $folderOfServiceExecutable
+
+Get-FileContent -filePath (Join-Path $folderOfServiceExecutable "appsettings.json")
+Get-FileContent -filePath (Join-Path $folderOfServiceExecutable "appsettings-after-install.json")
+Get-FileContent -filePath (Join-Path $folderOfServiceExecutable "info.json")
+Get-FileContent -filePath (Join-Path $folderOfServiceExecutable "config.json")
 
 # Check APIs accessibility
-Test-ServiceApiAvailability -url "https://api.viio.io/employee-management/v1/employees/email/test@mail.com"
-Test-ServiceApiAvailability -url "https://api.viio.io/desktop/v1/settings/test"
+Test-ServiceApiAvailability -url "https://api.viio.io/employee-management/v1/employees/email/test@example.com"
+Test-ServiceApiAvailability -url "https://api.viio.io/desktop/v1/settings/windows" 
+
+## Device ID
+Get-DeviceUUID
+
+## File attribute with Version
 
 # Ensures no value is returned in the end
 return

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -1,7 +1,15 @@
 # Service name (replace with your specific service name)
 $SERVICE_NAME = "ViioDesktopAgent"
 
-# Function to check if the service is installed
+function Test-AdminPrivileges {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $windowsPrincipal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
+
+    return $windowsPrincipal.IsInRole($adminRole)
+}
+
+# Function to check if the service is installed and its status
 function Confirm-ServiceInstalled {
     param (
         [string]$serviceName
@@ -12,14 +20,75 @@ function Confirm-ServiceInstalled {
     $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
     if ($service) {
         Write-Host "$serviceName is installed."
+        Write-Host ""
         Write-Host "Service Status: $($service.Status)"
+        Write-Host ""
         Write-Host "Startup Type: $(Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'").StartMode"
     } else {
         Write-Host "$serviceName is not installed."
     }
 }
 
+# Function to print all files in service installation folder
+function Get-ServiceInstallFolderAndFiles {
+    param (
+        [string]$serviceName
+    )
+
+    # Get the service object
+    $service = Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'"
+
+    Write-Host ""
+    if ($service) {
+        # Extract the executable path from the service's executable path
+        # Remove double quotes and extract the directory path
+        $executablePath = $service.PathName -replace '^"(.+)"$', '$1'
+        $serviceFolderPath = [System.IO.Path]::GetDirectoryName($executablePath)
+
+        Write-Host "Executable Path for Service '$serviceName': $executablePath"
+        Write-Host ""
+        Write-Host "Files in the folder of the executable:"
+
+        # Get and list all files in the directory with details
+        Get-ChildItem -Path $serviceFolderPath -File | Select-Object Name, Length, CreationTime, LastWriteTime | Format-List
+    } else {
+        Write-Host "Service '$serviceName' is not installed on this system."
+    }
+}
+
+function Test-ServiceApiAvailability {
+    param (
+        [string]$url
+    )
+
+    try {
+        $response = Invoke-WebRequest -Uri $url -Method 'GET' -UseBasicParsing
+        if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+            Write-Host "API at $url is available. Status Code: $($response.StatusCode)" -ForegroundColor Green
+        } else {
+            Write-Host "API at $url responded, but with a non-successful status code: $($response.StatusCode)" -ForegroundColor Yellow
+        }
+    } catch {
+        Write-Host "API at $url is not available. Error: $_" -ForegroundColor Red
+    }
+}
+
+# MAINs
+
+# Check if running as Administrator
+if (-not (Test-AdminPrivileges)) {
+    Write-Host "This script is better to run as an Administrator." -ForegroundColor Red
+}
+
+# Check if the service is installed and its status
 Confirm-ServiceInstalled -serviceName $SERVICE_NAME
+
+# Print all files in service installation folder
+Get-ServiceInstallFolderAndFiles -serviceName $SERVICE_NAME
+
+# Check APIs accessibility
+Test-ServiceApiAvailability -url "https://api.viio.io/employee-management/v1/employees/email/test@mail.com"
+Test-ServiceApiAvailability -url "https://api.viio.io/desktop/v1/settings/test"
 
 # Ensures no value is returned in the end
 return

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -1,0 +1,25 @@
+# Service name (replace with your specific service name)
+$SERVICE_NAME = "ViioDesktopAgent"
+
+# Function to check if the service is installed
+function Confirm-ServiceInstalled {
+    param (
+        [string]$serviceName
+    )
+
+    Write-Host "Checking if $serviceName is installed..."
+    
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if ($service) {
+        Write-Host "$serviceName is installed."
+        Write-Host "Service Status: $($service.Status)"
+        Write-Host "Startup Type: $(Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'").StartMode"
+    } else {
+        Write-Host "$serviceName is not installed."
+    }
+}
+
+Confirm-ServiceInstalled -serviceName $SERVICE_NAME
+
+# Ensures no value is returned in the end
+return

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -124,7 +124,7 @@ function Test-ServiceApiAvailability {
 
             # Check if response content is not empty
             if ([string]::IsNullOrWhiteSpace($response.Content)) {
-                Write-Warning "Response content is empty."
+                Write-Warning "Response content is empty of url: $url."
             } else {
                 Write-Output "Response Content: $($response.Content)"
             }


### PR DESCRIPTION
## Description

Scripts for Windows and MacOs to be running locally for checking Desktop Agent installation and configuration

## Motivation and Context

A few customers are facing issues during desktop agent installation or at some point after installation.

To troubleshoot that usually requires hoping in a call with an engineer to investigate the issue, which sometimes is difficult to achieve. Moreover, usually, there are the same issues.

Automating troubleshooting process by simply providing a script will improve customer experience and free up support time.

closes https://github.com/viio-io/desktop-agent/issues/433

## Affected areas

Support activities after Desktop Agent installation to customer hardware.

## Breaking Changes

No, it is new feature.

## How Has This Been Tested?

Locally during development with emulating different outages during Desktop Agent installation.


## Results

provided [here](https://github.com/viio-io/desktop-agent/issues/433#issuecomment-1912184976)