### PR TITLE
extend windows troubleshooting script with UserInfo output

### DIFF
--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -172,6 +172,15 @@ function Get-DeviceUUID {
     Write-Output "Machine Name: $env:COMPUTERNAME"
 }
 
+# Function to get user info
+function Get-UserInfo {
+    $username = [System.Environment]::UserName
+    $userdomain = [System.Environment]::UserDomainName
+
+    Write-Output "`nUser Name: $username"
+    Write-Output "User Domain: $userdomain"
+}
+
 # MAINs
 
 # Check if running as Administrator
@@ -201,6 +210,9 @@ Get-LatestFileContent -folderPath (Join-Path $folderOfServiceExecutable "logs")
 
 ## Device ID
 Get-DeviceUUID
+
+## Logged User Info
+Get-UserInfo
 
 # Get OS standart service log messages
 Get-ServiceLog -serviceName $SERVICE_NAME


### PR DESCRIPTION
## Description

Ability to print data about logged user in troubleshooting script.

This logic align with the way how DesktopAgent knows logged user after installation. See:

https://github.com/viio-io/desktop-agent/blob/main/src/DesktopAgent.AfterInstall/Services/AfterInstallService.cs#L32


## Motivation and Context

related to https://github.com/viio-io/desktop-agent-domain/issues/526

follow Slack thread: https://oveoio.slack.com/archives/C0708ULT1RC/p1724150275569619?thread_ts=1722930592.519489&cid=C0708ULT1RC

> We see 673 devices under the customer since 2024.07.01. And 392 of them have hardwareId started with VMware. E.g. `VMware-42 2a 59 86 52 57 57 8a-60 4b 32 c2 2b f0 21 cb`.

> 789 unique installations on VMware. VMware devices report info about Adobe app - 677 in total
and 112 VMware devices have not reported any Adobe app yet

> There was one task back in the day to show unmapped devices in the UI, but the time for it never came. 

> Is there any way from the Agent to see who is the logged in user in a VM?

> DesktopAgent.exe  got UserName and UserDomainName from Operation System; built email, for example `vmuser@domain.com`. Sent that value to our API. The API returned 404 employee not found
agent is woking w/o knowing employee

>  let's modify the troubleshooting script to print UserName, UserDomain of logged user

## Affected areas

New functionality for troubleshooting script for Windows.

## Breaking Changes

No

## How Has This Been Tested?

Locally on windows virtual machine