### PR TITLE
feat: Windows troubleshooting script: print all available registry properties

### DIFF
--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -189,6 +189,8 @@ function Get-UserInfo {
 
 function Get-Registry {
 
+    Write-Output "`nChecking registry..."
+
     $displayNameFragment = "Viio"          # what to match in DisplayName
 
     # -- registry hives to search -------------------------------------------------
@@ -235,6 +237,8 @@ function Get-Registry {
             }
         }
     }
+    
+    Write-Output "`nRegistry check finished"
 }
 
 # MAINs

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -237,7 +237,7 @@ function Get-Registry {
             }
         }
     }
-    
+
     Write-Output "`nRegistry check finished"
 }
 

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -228,11 +228,11 @@ function Get-Registry {
                 $props.DisplayName -like "*$displayNameFragment*")
             {
                 # ----- full dump (every name/value on its own line) -------------
-                Write-Host "`n[$keyPath]" -ForegroundColor Cyan
+                Write-Output "`n[$keyPath]" -ForegroundColor Cyan
                 $props.PSObject.Properties |
                     Sort-Object Name |
                     ForEach-Object {
-                        Write-Host ("{0} : {1}" -f $_.Name, $_.Value)
+                        Write-Output ("{0} : {1}" -f $_.Name, $_.Value)
                     }
             }
         }

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -193,13 +193,15 @@ function Get-Registry {
 
     # -- registry hives to search -------------------------------------------------
     $registryPaths = @(
-        # machine – 64-bit view
-        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
-        # machine – 32-bit view on 64-bit OS
-        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
-        # current user – both views
-        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
-        'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+        # 1. Machine-wide (64-bit view)
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        # 2. Machine-wide (32-bit view on 64-bit OS)
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+
+        # 3. Per-user (current logged-on user, 64-bit view)
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        # 4. Per-user (current logged-on user, 32-bit view on 64-bit OS)
+        "HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
     )
 
     # user hives for **every** loaded profile (Citrix, RDS, etc.)

--- a/windows.troubleshooting.ps1
+++ b/windows.troubleshooting.ps1
@@ -204,17 +204,15 @@ function Get-Registry {
         "HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
     )
 
-    # user hives for **every** loaded profile (Citrix, RDS, etc.)
+    # 5. Per-user **for every loaded profile** (useful on multi-user servers)
     Get-ChildItem HKU:\ -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match '^HKEY_USERS\\S-\d-\d+-.+' } |   # only SIDs
+        Where-Object { $_.Name -match '^HKEY_USERS\\S-\d-\d+-.+' } |   # only SIDs# keep only SIDs
         ForEach-Object {
             $sid = $_.PSChildName
             $registryPaths += "HKU:\$sid\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
             $registryPaths += "HKU:\$sid\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
         }
-    # ---------------------------------------------------------------------------
-
-    $summary = @()
+    # ----------------------------------------------------------------------
 
     foreach ($path in $registryPaths) {
 
@@ -236,14 +234,6 @@ function Get-Registry {
                     }
             }
         }
-    }
-
-    if ($summary.Count) {
-        Write-Host "`n=== Compact summary ===" -ForegroundColor Yellow
-        $summary | Sort-Object DisplayName | Format-Table -AutoSize
-    }
-    else {
-        Write-Warning "No Viio-related uninstall entries were found."
     }
 }
 


### PR DESCRIPTION
## Summary

<!--- Describe your changes in detail -->

Windows troubleshooting script extended to print all available registry properties, instead of printing hardcoded list

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

related to https://github.com/viio-io/desktop-agent/issues/481

## Testing

Locally 

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/8308040a-fef5-4d31-828d-91cd6d8ed354" />

[result.txt](https://github.com/user-attachments/files/20942417/result.txt)

