### PR TITLE
chore: add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/ryanlewis/pre-commit-mirror-textlint
+    rev: v15.7.1
+    hooks:
+      - id: textlint
+        types: [markdown, text]
+        additional_dependencies:
+          - textlint@15.2.3
+          - textlint-rule-terminology@5.2.16
+        args: ["--rule", "terminology", "--fix"]
+  - repo: local
+    hooks:
+      - id: oxfmt
+        name: oxfmt
+        language: node
+        entry: oxfmt --write --no-error-on-unmatched-pattern
+        additional_dependencies:
+          - oxfmt@0.55.0
+        types_or: [yaml, markdown, json]


### PR DESCRIPTION
Adds a `.pre-commit-config.yaml` so this repo gets the same local quality gates as the rest of the org. Most org repos already have it — this brings this repo in line.

### Hooks
- **gitleaks** — secret scanning
- **pre-commit-hooks** — `end-of-file-fixer`, `trailing-whitespace`
- **textlint** (terminology rule) — consistent product/tech terminology in markdown
- **oxfmt** — formats yaml/markdown/json

oxfmt is intentionally scoped to config files (yaml/markdown/json) so it does not conflict with this repo's existing source formatter (eslint/prettier). Mirrors the non-invasive base used across the org (e.g. `mjml-templates`).

### To start using it locally
```
pip install pre-commit   # or: brew install pre-commit
pre-commit install
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
